### PR TITLE
Handle gzipped tiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ stack exec -- simple-mbtiles-server --mbtilesFile your_mbtiles_file.mbtiles -b
 
 ## Code formating
 Use Ormolu: <https://github.com/tweag/ormolu>
+
+### Content Encoding
+
+By default, Tippecanoe produces gzipped tiles. This causes a `Unimplimented type: 3` error if the content-encoding header on the response is not set correctly.
+
+Simple mbtiles uses the "generator_opts" field in the tile metadata to determine whether the last generator command included the -pC option to produce uncompressed tiles (see Tippecanoe readme for explanation). If if did, it will set content encoding to "identity" or uncompressed. Otherwise, it will set "gzip" as the content encoding.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                simple-mbtiles-server
-version:             0.0.1.0
+version:             0.0.2.0
 github:              "zellige/simple-mbtiles-server"
 license:             "Apache-2.0"
 author:              "Zellige"

--- a/src/Controller.hs
+++ b/src/Controller.hs
@@ -4,6 +4,7 @@ import qualified DB
 import qualified Database.Mbtiles as Mbtiles
 import qualified Routes
 import qualified Servant
+import qualified Types.Config as Config
 
-server :: Mbtiles.MbtilesPool -> Servant.Server Routes.API
-server spatialConns = DB.tilesDB spatialConns Servant.:<|> DB.metadataDB spatialConns Servant.:<|> Servant.serveDirectoryFileServer "static"
+server :: Config.ContentEncoding -> Mbtiles.MbtilesPool -> Servant.Server Routes.API
+server contentEncoding spatialConns = DB.tilesDB contentEncoding spatialConns Servant.:<|> DB.metadataDB spatialConns Servant.:<|> Servant.serveDirectoryFileServer "static"

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -12,6 +12,7 @@ import qualified System.Exit as SystemExit
 import qualified Data.Text as Text
 import qualified Routes
 import qualified Controller
+import qualified DB (getTileEncoding)
 
 debug :: Wai.Middleware
 debug app req resp = do
@@ -31,6 +32,8 @@ startApp mbtilesfile startBrowser = do
       putStrLn $ show e
       SystemExit.exitWith (SystemExit.ExitFailure 2)
     Right spatialConns -> do
+        contentEncoding <- DB.getTileEncoding spatialConns
+        putStrLn $ show contentEncoding
         if startBrowser then do
             b <- Browser.openBrowser $ Text.unpack "http://127.0.0.1" ++ ":" ++ "8765"
             if b
@@ -40,4 +43,3 @@ startApp mbtilesfile startBrowser = do
             action
         where
             action = Wai.run 8765 $ debug $ Servant.serve Routes.api (Controller.server spatialConns)
-

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -33,7 +33,8 @@ startApp mbtilesfile startBrowser = do
       SystemExit.exitWith (SystemExit.ExitFailure 2)
     Right spatialConns -> do
         contentEncoding <- DB.getTileEncoding spatialConns
-        putStrLn $ show contentEncoding
+        let
+          action = Wai.run 8765 $ debug $ Servant.serve Routes.api (Controller.server contentEncoding spatialConns)
         if startBrowser then do
             b <- Browser.openBrowser $ Text.unpack "http://127.0.0.1" ++ ":" ++ "8765"
             if b
@@ -41,5 +42,3 @@ startApp mbtilesfile startBrowser = do
                 else print "Failed to start browser"
         else
             action
-        where
-            action = Wai.run 8765 $ debug $ Servant.serve Routes.api (Controller.server spatialConns)

--- a/src/Routes.hs
+++ b/src/Routes.hs
@@ -16,7 +16,7 @@ type API ="tiles"
     :> Capture "z" Int
     :> Capture "x" Int
     :> Capture "y" Text.Text
-    :> Get '[OctetStream] BSS.ByteString
+    :> Get '[OctetStream] (Headers '[Header "Content-Encoding" Text.Text] BSS.ByteString)
     :<|> "metadata"
     :> Get '[JSON] (HashMap.HashMap Text.Text Text.Text)
     :<|> Raw

--- a/src/Types/Config.hs
+++ b/src/Types/Config.hs
@@ -9,6 +9,7 @@
 module Types.Config where
 
 import qualified Options.Generic as OptionsGeneric
+import qualified Data.Text as Text
 
 data CommandLine w
   = CommandLine
@@ -27,3 +28,5 @@ instance OptionsGeneric.ParseRecord (CommandLine OptionsGeneric.Wrapped) where
   parseRecord = OptionsGeneric.parseRecordWithModifiers modifiers
 
 deriving instance Show (CommandLine OptionsGeneric.Unwrapped)
+
+type ContentEncoding = Text.Text


### PR DESCRIPTION
This avoids the `Unimplemented type: 3` error when trying to serve gzipped tiles (the Tippecanoe default).