### PR TITLE
Remove setup-stack action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,6 @@ jobs:
     - name: Get code
       uses: actions/checkout@v2
     
-    - name: Setup Stack
-      uses: mstksg/setup-stack@v2
-    
     - name: Cache Stack downloads
       uses: actions/cache@v1
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,6 @@ jobs:
     - name: Get code
       uses: actions/checkout@v2
     
-    - name: Setup Stack
-      uses: mstksg/setup-stack@v2
-    
     - name: Cache Stack downloads
       uses: actions/cache@v1
       env:
@@ -107,9 +104,6 @@ jobs:
     steps:
     - name: Get code
       uses: actions/checkout@v2
-    
-    - name: Setup Stack
-      uses: mstksg/setup-stack@v2
     
     - name: Cache Stack downloads
       uses: actions/cache@v1


### PR DESCRIPTION
As per https://github.com/mstksg/setup-stack/issues/7 the OSX builds are no longer working.

This is apparently no longer needed as github includes stack by default.